### PR TITLE
Predict tests to run when modify uncovered lines

### DIFF
--- a/lib/what_to_run/differ.rb
+++ b/lib/what_to_run/differ.rb
@@ -45,9 +45,9 @@ module WhatToRun
       # The possible param value that this method might receive
       # are the following
       #
-      # @param result positive => should be run the test
-      # @param result negative => should be run the test
-      # @param result nil      => should be run the test
+      # @param result positive => should run the test
+      # @param result negative => should run the test
+      # @param result nil      => should run the test
       # @param result zero     => should not run the test
       #
       # This method will convert negative and nil values to 1,

--- a/lib/what_to_run/differ.rb
+++ b/lib/what_to_run/differ.rb
@@ -1,31 +1,65 @@
 module WhatToRun
   class Differ
     class << self
-      def coverage_delta(before, after)
-        after.each_with_object({}) do |(file_name, after_lines_cov), delta|
-          before_lines_cov = before[file_name]
+      ##
+      # Gives the delta beteween the coverage result
+      # before and after a test run and before start
+      # the test suite
+      #
+      # Results in the lines that may trigger the test
+      # that gave the after result
 
-          # skip arrays that are exactly the same
-          next if before_lines_cov == after_lines_cov
+      def coverage_delta(cov_before, cov_after, cov_before_suite)
+        cov_after.each_with_object({}) do |(file_name, lines_cov_after), delta|
+          lines_cov_before = cov_before[file_name]
+          lines_cov_before_suite = cov_before_suite[file_name]
 
-          # subtract the old coverage from the new coverage
-          lines_delta = lines_cov_delta(before_lines_cov, after_lines_cov)
+          next unless file_covered?(lines_cov_before, lines_cov_after)
 
-          # add the "diffed" coverage to the hash
+          lines_delta = lines_cov_delta \
+            lines_cov_before_suite, lines_cov_before, lines_cov_after
+
           delta[file_name] = lines_delta
         end
       end
 
-      def lines_cov_delta(before_lines_cov, after_lines_cov)
-        after = Array(after_lines_cov)
-        before = Array(before_lines_cov)
+      ##
+      # It needs to diff the diff of before and after
+      # with the coverage before the test suite in order
+      # to include the uncovered lines to all tests that
+      # touch this file
+
+      def lines_cov_delta(before_suite, before, after)
+        delta = diff before_suite, diff(before, after)
+        delta.map(&method(:normalize_cov_result))
+      end
+
+      def diff(before, after)
+        after = Array(after)
+        before = Array(before)
 
         after.zip(before).map do |lines_after, lines_before|
           lines_after ? lines_after - lines_before.to_i : lines_after
         end
       end
+
+      ##
+      # Marks lines to be ran
+      #
+      # @param result positive => covered
+      # @param result negative => covered
+      # @param result nil      => not covered
+      # @param result zero     => not covered; within a method
+
+      def normalize_cov_result(result)
+        result.nil? || result.to_i < 0 ? 1 : result
+      end
+
+      def file_covered?(cov_before, cov_after)
+        cov_before != cov_after
+      end
     end
 
-    private_class_method :lines_cov_delta
+    private_class_method :lines_cov_delta, :file_covered?
   end
 end

--- a/lib/what_to_run/differ.rb
+++ b/lib/what_to_run/differ.rb
@@ -3,12 +3,11 @@ module WhatToRun
     class << self
       ##
       # Gives the delta beteween the coverage result
-      # before and after a test run and before start
+      # before and after a test run and before starting
       # the test suite
       #
       # Results in the lines that may trigger the test
       # that gave the after result
-
       def coverage_delta(cov_before, cov_after, cov_before_suite)
         cov_after.each_with_object({}) do |(file_name, lines_cov_after), delta|
           lines_cov_before = cov_before[file_name]
@@ -28,7 +27,6 @@ module WhatToRun
       # with the coverage before the test suite in order
       # to include the uncovered lines to all tests that
       # touch this file
-
       def lines_cov_delta(before_suite, before, after)
         delta = diff before_suite, diff(before, after)
         delta.map(&method(:normalize_cov_result))
@@ -44,13 +42,27 @@ module WhatToRun
       end
 
       ##
-      # Marks lines to be ran
+      # The possible param value that this method might receive
+      # are the following
       #
-      # @param result positive => covered
-      # @param result negative => covered
-      # @param result nil      => not covered
-      # @param result zero     => not covered; within a method
-
+      # @param result positive => should be run the test
+      # @param result negative => should be run the test
+      # @param result nil      => should be run the test
+      # @param result zero     => should not run the test
+      #
+      # This method will convert negative and nil values to 1,
+      # which will make them represent lines that should be run.
+      # The positive lines can be kept as they are since this mean
+      # they will be run.
+      #
+      # The only exception case is the 0 result which will be kept
+      # as it is so we don't run lines within the not called methods
+      #
+      # This introduces false positives to avoid missing tests that
+      # depends on lines that are evaluated when the file is required
+      #
+      # @return 1 to represent that this line should trigger the current test
+      # @return 0 to represent that this line should not trigger the current test
       def normalize_cov_result(result)
         result.nil? || result.to_i < 0 ? 1 : result
       end

--- a/lib/what_to_run/minitest.rb
+++ b/lib/what_to_run/minitest.rb
@@ -3,12 +3,13 @@ configure = -> do
   require 'coverage_peeker'
   require 'what_to_run/tracker'
 
-  WhatToRun::Tracker.start
   Coverage.start
 
   require 'minitest'
 
   class Minitest::Runnable
+    Minitest.before_run {WhatToRun::Tracker.start}
+
     Minitest.after_run {WhatToRun::Tracker.finish}
 
     class << self

--- a/lib/what_to_run/rspec.rb
+++ b/lib/what_to_run/rspec.rb
@@ -3,9 +3,11 @@ configure = -> do
   require 'coverage_peeker'
   require 'what_to_run/tracker'
 
-  WhatToRun::Tracker.start
-
   Coverage.start
+
+  RSpec.configuration.before(:suite) do
+    WhatToRun::Tracker.start
+  end
 
   RSpec.configuration.after(:suite) do
     WhatToRun::Tracker.finish

--- a/lib/what_to_run/tracker.rb
+++ b/lib/what_to_run/tracker.rb
@@ -1,4 +1,5 @@
 require 'sqlite3'
+require 'coverage_peeker'
 require_relative 'differ'
 
 module WhatToRun
@@ -15,11 +16,13 @@ module WhatToRun
             log blob
           )
         SQL
+
+        @@before_suite = CoveragePeeker.peek_result
       end
 
       def track(description, before, after)
         coverage = Marshal.dump \
-          Differ.coverage_delta(before, after)
+          Differ.coverage_delta(before, after, @@before_suite)
 
         DB.execute 'insert into coverage VALUES(?, ?)',
           [description, SQLite3::Blob.new(coverage)]

--- a/lib/what_to_run/tracker.rb
+++ b/lib/what_to_run/tracker.rb
@@ -17,12 +17,12 @@ module WhatToRun
           )
         SQL
 
-        @@before_suite = CoveragePeeker.peek_result
+        @before_suite = CoveragePeeker.peek_result
       end
 
       def track(description, before, after)
         coverage = Marshal.dump \
-          Differ.coverage_delta(before, after, @@before_suite)
+          Differ.coverage_delta(before, after, @before_suite)
 
         DB.execute 'insert into coverage VALUES(?, ?)',
           [description, SQLite3::Blob.new(coverage)]

--- a/spec/differ_spec.rb
+++ b/spec/differ_spec.rb
@@ -4,6 +4,14 @@ describe WhatToRun::Differ do
   subject {WhatToRun::Differ}
 
   describe 'coverage_delta' do
+    let(:before_suite) do
+      {
+        'foo.rb' =>               [nil, 1,   0,   0, 0,   nil],
+        'not_changed.rb' =>       [nil, nil, nil, 1, nil, nil],
+        'nil_initial_coverage' => nil
+      }
+    end
+
     let(:before) do
       {
         'foo.rb' =>               [nil, 1,   1,   1, 2,   nil],
@@ -20,20 +28,47 @@ describe WhatToRun::Differ do
       }
     end
 
-    let(:delta) {subject.coverage_delta(before, after)}
+    let(:delta) {subject.coverage_delta(before, after, before_suite)}
 
-    it 'subtracts the old coverage from the new one' do
+    it 'turns calculated negative results into 1' do
+      expect(delta['foo.rb'][1]).to eq(1)
+    end
+
+    it 'turns nil results into 1' do
+      expect(delta['foo.rb'].first).to eq(1)
+      expect(delta['foo.rb'].last).to eq(1)
+    end
+
+    it 'subtracts the old coverages from the new one' do
       expect(delta['foo.rb']).to \
-        match_array([nil, 0, 1, 2, 0, nil])
+        match_array([1, 1, 1, 2, 0, 1])
     end
 
     it 'doest not include unchanged coverages' do
       expect(delta['not_changed.rb']).to be_nil
     end
 
-    it 'keeps after data if before data is empty' do
+    it 'normalize after data if before data is empty' do
       expect(delta['nil_initial_coverage']).to \
-        match_array(after['nil_initial_coverage'])
+        match_array([1, 3, 1])
+    end
+
+    describe 'normalize_cov_result' do
+      it 'turns negative values into 1' do
+        expect(subject.normalize_cov_result(-1)).to eq(1)
+      end
+
+      it 'turns nil values into 1' do
+        expect(subject.normalize_cov_result(nil)).to eq(1)
+      end
+
+      it 'doesnt change 0' do
+        expect(subject.normalize_cov_result(0)).to eq(0)
+      end
+
+      it 'doesnt change positive values' do
+        expect(subject.normalize_cov_result(2)).to eq(2)
+      end
     end
   end
 end


### PR DESCRIPTION
This introduces false positive results in order to
include lines evaluated on require, blank lines and
method and class declarations

Right now the false positives seems inevitable

It resolves #9

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dyegocosta/what_to_run/10)

<!-- Reviewable:end -->
