### PR TITLE
Simplify sanity specs

### DIFF
--- a/spec/sanity/sanity_shared_examples.rb
+++ b/spec/sanity/sanity_shared_examples.rb
@@ -1,9 +1,12 @@
+require 'English'
+
 shared_examples 'a sanity check' do |framework, run_cmd|
   describe framework, :slow do
     let(:sandbox_uuid) { SecureRandom.uuid[0..7] }
     let(:app_path) { File.expand_path('fake_app', File.dirname(__FILE__)) }
     let(:sandbox_path)  { File.expand_path(sandbox_uuid, File.dirname(__FILE__)) }
-    let(:sandbox_app_path) { File.join(sandbox_path, 'fake_app')}
+    let(:sandbox_app_path) { File.join(sandbox_path, 'fake_app') }
+    let(:framework) { framework }
 
     before do
       FileUtils.mkdir sandbox_path
@@ -16,13 +19,12 @@ shared_examples 'a sanity check' do |framework, run_cmd|
       let(:what_to_run_dir) { File.join(sandbox_app_path, '.what_to_run') }
 
       before do
-        fork do
-          `cd #{sandbox_app_path};
-            git init; git add -A; git commit -m \'Initial commit\';
-            BUNDLE_GEMFILE=./Gemfile COLLECT=1 bundle exec #{run_cmd}`
+        Bundler.with_clean_env do
+          Dir.chdir(sandbox_app_path) do
+            `git init; git add -A; git commit -m \'Initial commit\';
+             COLLECT=1 bundle exec #{run_cmd}`
+          end
         end
-
-        Process.wait
       end
 
       it 'creates .what_to_run dir' do
@@ -35,33 +37,17 @@ shared_examples 'a sanity check' do |framework, run_cmd|
       end
 
       describe 'what_to_run command' do
-        let(:what_to_run_result) { @what_to_run_result }
-        let(:process_status) { @process_status }
-
-        let(:what_to_run) do
-          -> do
-            reader, writer = IO.pipe
-
-            fork do
-              reader.close
-
-              writer.write `cd #{sandbox_app_path};
-                BUNDLE_GEMFILE=./Gemfile bundle exec what_to_run #{framework}`
-            end
-
-            @process_status = Process.wait2[1]
-
-            writer.close
-
-            @what_to_run_result = reader.read
+        def exec_what_to_run
+          Dir.chdir(sandbox_app_path) do
+            `bundle exec what_to_run #{framework}`
           end
         end
 
         context 'without any changes' do
           it 'runs nothing' do
-            what_to_run.call
-            expect(process_status.exitstatus).to eq(0)
-            expect(what_to_run_result).to eq('')
+            output = exec_what_to_run
+            expect($CHILD_STATUS.to_i).to eq(0)
+            expect(output).to eq('')
           end
         end
 
@@ -73,10 +59,10 @@ shared_examples 'a sanity check' do |framework, run_cmd|
           end
 
           it 'runs the predicted examples' do
-            what_to_run.call
+            output = exec_what_to_run
 
             what_to_run_result_matches.each do |match|
-              expect(what_to_run_result).to include(match)
+              expect(output).to include(match)
             end
           end
         end


### PR DESCRIPTION
- Remove unnecessary forking and pipes
- Use Bundler.with_clean_env instead of setting Gemfile paths

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dyegocosta/what_to_run/18)

<!-- Reviewable:end -->
